### PR TITLE
Improve viewport unit fallback and polyfill stability

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -13,15 +13,15 @@
   --font-sans: 'SF Pro Display', 'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', 'Segoe UI', 'Inter', sans-serif;
 }
 
-@supports (height: 100svh) {
-  :root {
-    --viewport-unit: 1svh;
-  }
-}
-
 @supports (height: 100dvh) {
   :root {
     --viewport-unit: 1dvh;
+  }
+}
+
+@supports (height: 100svh) {
+  :root {
+    --viewport-unit: 1svh;
   }
 }
 


### PR DESCRIPTION
## Summary
- prefer the stable small viewport height when available and only fallback to the dynamic unit when necessary
- harden the JavaScript viewport-unit polyfill by locking onto non-keyboard heights, persisting that lock through deferred updates, and ignoring visualViewport-only chrome animations

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d05c68e2348331841378662a84e2bc