### PR TITLE
Adjust viewport unit detection for dynamic viewport support

### DIFF
--- a/script.js
+++ b/script.js
@@ -3,7 +3,9 @@
   if (!root) return;
 
   const supportsCSS = typeof window.CSS !== 'undefined' && typeof window.CSS.supports === 'function';
-  const supportsStableUnit = supportsCSS && window.CSS.supports('height', '100svh');
+  const supportsStableUnit =
+    supportsCSS &&
+    (window.CSS.supports('height', '100dvh') || window.CSS.supports('height', '100lvh'));
 
   if (supportsStableUnit) {
     return;

--- a/styles.css
+++ b/styles.css
@@ -19,7 +19,7 @@
   }
 }
 
-@supports (height: 100svh) {
+@supports (height: 100svh) and not (height: 100dvh) {
   :root {
     --viewport-unit: 1svh;
   }


### PR DESCRIPTION
## Summary
- update the viewport unit polyfill to treat `dvh`/`lvh` support as stable units so the script still runs on `svh`-only browsers
- wrap the `svh` CSS override in a supports query that excludes `dvh` so the dynamic viewport unit wins when both are available

## Testing
- not run (mobile viewport verification required outside container)


------
https://chatgpt.com/codex/tasks/task_e_68d060dbc7f48331a60ba8a413c5ba06